### PR TITLE
Don't use deprecated "directories" key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
     "url": "http://github.com/Tim-Smart/node-closure.git"
   },
   "engine": [ "node >=0.1.90" ],
-  "directories": {
-    "lib": "./lib/closure-compiler"
-  }
+  "main": "./lib/closure-compiler"
 }
 


### PR DESCRIPTION
package.json: Use 'main' key instead of 'directories' so that require('closure-compiler') works with newer npm versions.
