### PR TITLE
Fix Git repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 , "author"      : "tim-smart"
 , "repository"  :
   { "type"      : "git"
-  , "url"       : "http://github.com/Tim-Smart/node-closure.git"
+  , "url"       : "git://github.com/tim-smart/node-closure.git"
   }
 , "engine"      : [ "node >=0.4" ]
 , "main"        : "./lib/index.js"


### PR DESCRIPTION
The URL is case-sensitive and was returning a 404.

Additionally use the git: scheme which is more flexible. The insteadOf and pushInsteadOf directives can be used to tell Git to pull from HTTP or push to SSH, for instance.
