### PR TITLE
fix: locate `compiler.jar` using Node's regular mechanism.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ path = require('path');
 
 JAVA_PATH = exports.JAVA_PATH = 'java';
 
-JAR_PATH = exports.JAR_PATH = path.join(__dirname, '../node_modules/google-closure-compiler/compiler.jar');
+JAR_PATH = exports.JAR_PATH = require.resolve('google-closure-compiler/compiler.jar');
 
 OPTIONS = exports.OPTIONS = {};
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -25,7 +25,8 @@ spawn = require('child_process').spawn
 path  = require 'path'
 
 JAVA_PATH = exports.JAVA_PATH = 'java'
-JAR_PATH  = exports.JAR_PATH  = path.join __dirname, '../node_modules/google-closure-compiler/compiler.jar'
+# Load `compiler.jar` using Node's regular lookup mechanism.
+JAR_PATH  = exports.JAR_PATH  = require.resolve('google-closure-compiler/compiler.jar');
 OPTIONS   = exports.OPTIONS   = {}
 
 exports.compile = (input, options, callback) ->


### PR DESCRIPTION
Newer npm versions change the installation location of node modules. Dependent
modules are not always installed into subfolders, in particular if there are
no version conflicts. That reduces file system usage, but also means this code
needs to be a bit more standard in how it locates the `compiler.jar`.