### PR TITLE
Automatically work with newer (or older) versions of Google Closure Compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "type": "git",
     "url": "git://github.com/tim-smart/node-closure.git"
   },
-  "dependencies": {
-    "google-closure-compiler": "20150901.x"
+  "peerDependencies": {
+    "google-closure-compiler": ">= 20150901.0.0"
   },
   "engine": [
     "node >=0.10"


### PR DESCRIPTION
- Make the association with google/closure-compiler weaker, allowing newer compiler versions to be used.
- Said another way: tim-smart/node-closure will not have to be updated for each new version of google/closure-compiler.

By making google/closure-compiler a _peer_ dependency instead of a direct dependency, we can give the developer a choice of which compiler version to use. If they don't specify it explicitly in their own package.json, they get the latest compiler. If they want a specific version, they just need to specify it as a dependency.
